### PR TITLE
TTH-8: Added routing between LandingPage and MatchPage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.6.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "reactstrap": "^8.9.0",
     "web-vitals": "^1.1.0"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,11 +1,28 @@
 import './App.css';
+import {
+  BrowserRouter as Router, Switch, Route
+} from "react-router-dom";
 import LandingPage from './views/LandingPage'
 import NavBar from './components/Navbar'
+import MatchPage from './views/MatchPage'
+
 function App() {
   return (
     <div>
-      <NavBar/>
-      <LandingPage/>      
+      <Router>
+        <NavBar />
+        <Switch>
+          <Route exact path="/">
+            <LandingPage /> 
+          </Route>
+          <Route path="/home">
+            <LandingPage /> 
+          </Route>
+          <Route path="/match">
+            <MatchPage />
+          </Route>
+        </Switch>    
+      </Router> 
     </div>
 
   );

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -6,8 +6,7 @@ import {
   NavbarBrand,
   Nav,
   NavItem,
-  NavLink,
-  NavbarText
+  NavLink
 } from 'reactstrap';
 
 function NavBar() {

--- a/frontend/src/views/LandingPage.js
+++ b/frontend/src/views/LandingPage.js
@@ -8,7 +8,7 @@ function LandingPage(){
         <div>
             <Explanation />
             <Features />
-            <Team/>
+            <Team />
         </div>
     )
 }

--- a/frontend/src/views/MatchPage.js
+++ b/frontend/src/views/MatchPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function MatchPage(){
+    return(
+        <div>
+            <h1>MatchPage</h1>
+        </div>
+    )
+}
+
+export default MatchPage;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, new feature...)
Routing added between website views: Landing Page and MatchPage


* **What is the current behavior? What does the code do before you made the new changes?** 
Displays landing page with static navbar


* **What is the new behavior?**
Navbar routes to the LandingPage through /home link and MatchPage through /match link. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR? Run a new command?)
react-router-dom dependency added. Make sure to rerun "npm install" or "npm install react-router-dom"


* **Other information**:
